### PR TITLE
Add assistant thinking state and logic. 

### DIFF
--- a/src/components/AssistantButton/AssistantButton.tsx
+++ b/src/components/AssistantButton/AssistantButton.tsx
@@ -76,10 +76,11 @@ export default function AssistantButton() {
     playAudio(input);
   };
 
-  // Define state variables for the result, recording status, and media recorder
+  // Define state variables for the result, recording status, assistant thinking and media recorder
   const [result, setResult] = useState();
   const [recording, setRecording] = useState(false);
   const [mediaRecorder, setMediaRecorder] = useState(null);
+  const [thinking, setThinking] = useState(false);
   // This array will hold the audio data
   let chunks: any = [];
   // This useEffect hook sets up the media recorder when the component mounts
@@ -95,6 +96,7 @@ export default function AssistantButton() {
   };
   // Function to stop recording
   const stopRecording = () => {
+    setThinking(true);
     toast("Thinking", {
       duration: 5000,
       icon: "💭",
@@ -126,6 +128,27 @@ export default function AssistantButton() {
     <div>
       <motion.div
         onClick={() => {
+          
+          // If assistant is thinking, don't do anything
+          if (thinking) {
+            toast("Please wait for the assistant to finish.", {
+              duration: 5000,
+              icon: "🙌",
+              style: {
+                borderRadius: "10px",
+                background: "#1E1E1E",
+                color: "#F9F9F9",
+                border: "0.5px solid #3B3C3F",
+                fontSize: "14px",
+              },
+              position: "top-right",
+            });
+            //Timer to reset thinking state
+            setTimeout(() => {
+              setThinking(false);
+            }, 1500);
+            return;
+          }
           if (typeof window !== "undefined" && !mediaRecorderInitialized) {
             // Set the init state to true, so we don't init on every click
             mediaRecorderInitialized ? null : setMediaRecorderInitialized(true);


### PR DESCRIPTION
Fixes #4 

Currently this uses a timer to reset the thinking variable. Would be best practice to dynamically update it as well as the duration for the thinking toast; probably wouldn't be too hard to implement. 