### PR TITLE
Add doom loop detection to prevent infinite tool call cycles

### DIFF
--- a/apps/cli/src/hooks/useChat.ts
+++ b/apps/cli/src/hooks/useChat.ts
@@ -209,6 +209,22 @@ export function useChat({
           }
         }
 
+        // Handle doom loop detection - append warning to content
+        if (event.type === "doom_loop" && event.doomLoop) {
+          const warning = `\n\n⚠️ Doom loop detected: "${event.doomLoop.tool}" called ${event.doomLoop.count} times with identical arguments. Breaking loop.`
+          fullContent += warning
+
+          setMessages((prev) => {
+            const updated = [...prev]
+            const lastIndex = updated.length - 1
+            updated[lastIndex] = {
+              ...updated[lastIndex],
+              content: fullContent,
+            }
+            return updated
+          })
+        }
+
         if (event.type === "done") {
           break
         }


### PR DESCRIPTION
  - **Prevents runaway sessions**: If the AI gets stuck calling the same tool repeatedly with identical arguments, it's now automatically detected and stopped
  - **Saves tokens and time**: No more watching helplessly as the model burns through your API credits in an infinite loop
  - **Clear feedback**: Users see a warning message explaining what happened and why the loop was broken